### PR TITLE
Coupon redemption activation message now matches old functionality

### DIFF
--- a/ecommerce/static/js/apps/email_confirm.js
+++ b/ecommerce/static/js/apps/email_confirm.js
@@ -1,0 +1,12 @@
+require([
+    'jquery'
+],
+    function($) {
+        'use strict';
+        $('.user-dropdown').click(
+            function() {
+                $('.user-dropdown-menu').toggleClass('expanded');
+            }
+        )
+    }
+);

--- a/ecommerce/static/sass/base/_variables.scss
+++ b/ecommerce/static/sass/base/_variables.scss
@@ -42,3 +42,9 @@ $lighter-base-font-color: rgb(100,100,100);
 $very-light-text: rgb(255,255,255); // #ffffff
 
 $lms-border-color: #c41731;
+
+
+// Variables imported from lms theme
+$border-color-2: rgb(8, 8, 8);
+$border-color-4: rgb(252, 252, 252);
+$dropdown-grey: rgb(200, 200, 200);

--- a/ecommerce/static/sass/partials/components/_user_dropdown.scss
+++ b/ecommerce/static/sass/partials/components/_user_dropdown.scss
@@ -1,0 +1,105 @@
+.user {
+    list-style: none;
+    padding: 0;
+    li.primary {
+        position: relative;
+    }
+    .user-dropdown {
+        font-size: $body-font-size;
+        padding: 0 ($baseline/2);
+        color: $grey;
+        border: none;
+        background: $white;
+        box-shadow: none;
+        .user-link {
+            display: block;
+            padding: 10px 13px 12px;
+            border-radius: 3px;
+            color: #8c8179;
+            font-size: 16px;
+            font-weight: 400;
+            text-decoration: none;
+            text-transform: uppercase;
+        }
+        &:focus {
+            outline: none;
+        }
+        .fa {
+            position: relative;
+            bottom: 4px;
+            margin-left: 15px;
+        }
+    }
+    .user-dropdown-menu {
+        background: $white;
+        border-radius: 4px;
+        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.3);
+        border: 1px solid $dropdown-grey;
+        display: none;
+        margin-top: 0;
+        margin-right: 10px;
+        padding: 8px 10px;
+        position: absolute;
+        right: 0;
+        top: 37px;
+        min-width: 120px;
+        z-index: 3;
+        &.expanded {
+            display: block;
+        }
+        &::before {
+            background: transparent;
+            border: {
+                top: 6px solid $border-color-4;
+                right: 6px solid $border-color-4;
+                bottom: 6px solid transparent;
+                left: 6px solid transparent;
+            }
+            box-shadow: 1px 0 0 0 $dropdown-grey, 0 -1px 0 0 $dropdown-grey;
+            content: "";
+            display: block;
+            height: 0px;
+            position: absolute;
+            @include transform(rotate(-45deg));
+            @include right(7px);
+            top: -5px;
+            width: 0px;
+        }
+        li {
+            display: block;
+            border-top: 1px dotted $border-color-2;
+            box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.05);
+            &:first-child {
+                border: none;
+                box-shadow: none;
+            }
+            >a {
+                border: 1px solid transparent;
+                border-radius: 3px;
+                @include box-sizing(border-box);
+                color: $crimson;
+                cursor: pointer;
+                display: block;
+                margin: 5px 0px;
+                overflow: hidden;
+                padding: 3px 10px 4px;
+                text-overflow: ellipsis;
+                @include transition(padding 0.15s linear 0s);
+                white-space: nowrap;
+                width: 100%;
+                &:link,
+                &:visited,
+                &:focus,
+                &:active {
+                    color: $grey;
+                }
+                &:hover {
+                    color: $m-teal;
+                    text-decoration: none;
+                }
+                text-align: left;
+                text-transform: uppercase;
+            }
+        }
+    }
+}

--- a/ecommerce/static/sass/partials/views/_error.scss
+++ b/ecommerce/static/sass/partials/views/_error.scss
@@ -3,7 +3,6 @@ i.fa {
 }
 
 #error-message .container {
-  padding-top: $container-padding-top;
   padding-bottom: spacing-vertical(small);
 }
 
@@ -42,9 +41,20 @@ i.fa {
 }
 
 .account-activation-message {
+  
+  font-family: $sans-serif;
 
   .enrollment-message-container {
     margin-bottom: 30px;
+  }
+
+  hr {
+    border: 1px solid $mortar;
+  }
+
+  h1 {
+    font-size: 2rem;
+    color: $crimson;
   }
 
   h2 {
@@ -78,4 +88,13 @@ i.fa {
     font-weight: bold;
     margin: 0;
   }
+}
+
+
+// user dropdown menu
+.toolbar{
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-end;
+  @import '../components/user_dropdown';
 }

--- a/ecommerce/templates/edx/email_confirmation_required.html
+++ b/ecommerce/templates/edx/email_confirmation_required.html
@@ -1,4 +1,5 @@
 {% extends 'edx/base.html' %}
+{% load staticfiles %}
 {% load i18n %}
 
 {% block title %}{% trans "Redeem" %}{% endblock %}
@@ -11,22 +12,51 @@
 {% block content %}
     <div id="error-message" class="account-activation-message">
         <div class="container">
+            <div class="toolbar">
+                <ol class="user">
+                    <li class="primary">
+                        <div role="group" aria-label="User menu">
+                            <button class="user-dropdown" aria-expanded="false">
+                                <a href="#" class="user-link">
+                                    {% trans "My Account" %} <span class="fa fa-sort-desc" aria-hidden="true"></span>
+                                    <span class="sr">More options dropdown</span>
+                                </a>
+                            </button>
+                            <ul class="user-dropdown-menu" aria-label="More Options" role="menu">
+                                <li class="dropdown-item item has-block-link"><a href="{{ lms_dashboard_url }}" class="action dropdown-menuitem">{% trans "Dashboard" %}</a></li>
+                                <li class="dropdown-item item has-block-link"><a href="{{ lms_base_url }}/account/settings" class="action dropdown-menuitem">{% trans "Settings" %}</a></li>
+                                <li class="dropdown-item item has-block-link"><a href="{{ lms_base_url }}/logout" role="menuitem" class="action dropdown-menuitem">{% trans "Sign Out" %}</a></li>
+                            </ul>
+                        </div>
+                    </li>
+                </ol>
+            </div>
             <div class="enrollment-message-container">
-                <h2 class="enrollment-message">
-                  {% trans "You are enrolling in: " %}
-                  <span class="course-title">{{ course_name }}</span>
-                </h2>
+                <h1 class="enrollment-message">
+                    You are not done yet! You must follow these steps to complete
+                    your account registration and your course enrollment. 
+                </h1>
+                <hr>
             </div>
             <div class="instruction">
-                <p class="instruction-info">
-                    <i class="fa fa-envelope-o" aria-hidden="true"></i>
-                    {% blocktrans %}An email has been sent to {{ user_email }} with a link for you to activate your account.{% endblocktrans %}
-                </p>
-              <h3 class="activate">{% trans "Why activate?" %}</h3>
-              <div class="activate-info">
-                  {% trans "We ask you to activate your account to ensure it is really you creating the account and to prevent fraud." %}
-              <div>
+                <ol class="instruction-steps">
+                    <li>
+                        Confirm your account email address. Go to your email to find an account 
+                        activation email. Follow the link in that email to activate your account.
+                    </li>
+                    <li>
+                        After you have activated your account, refresh this page to continue course
+                        enrollment, or re-open the original course enrollment link sent to you by 
+                        HMX.
+                    </li>
+                </ol>
+                If your need assistance, contact 
+                <a href="mailto:onlinelearning@hms.harvard.edu">onlinelearning@hms.harvard.edu</a>
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block javascript %}
+    <script src="{% static 'js/apps/email_confirm.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR makes the coupon redemption page match the old style and functionality.

**Testing instructions**:

1. Set up ecommerce environment
2. Visit coupon redemption page at ``/coupons/offer/?code=CODE``
3. Enrol in a course, and create a new account at the login screen
4. The redemption page should match the old page screenshot.

**Reviewers**
- [ ] @kaizoku 