### PR TITLE
Fix course image alignment in coupon offer view

### DIFF
--- a/ecommerce/static/sass/partials/views/_coupon_offer.scss
+++ b/ecommerce/static/sass/partials/views/_coupon_offer.scss
@@ -203,9 +203,7 @@
                     line-height: 1.2;
                 }
                 .image-container {
-                    display: flex;
-                    flex-direction: column-reverse;
-                    height: 150px;
+                    position: relative;
                 }
             }
         }

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -21,6 +21,8 @@
                 <div class="offer-item col-xs-12">
                     <div class="col-sm-3">
                         <div class="image-container">
+                            <img class="img-responsive" src="<%= course.attributes.image_url %>"
+                                 alt="<%= course.attributes.title %>"/>
                             <div class="voucher-valid-until">
                                 <p><%- gettext('Discount valid until') %></p>
                                 <p><%= course.attributes.voucher_end_date %></p>
@@ -30,8 +32,6 @@
                                     <span><%- gettext('off') %></span></p>
                                 </div>
                             <% } %>
-                            <img class="img-responsive" src="<%= course.attributes.image_url %>"
-                                 alt="<%= course.attributes.title %>"/>
                         </div>
                     </div>
                     <div class="col-sm-9 col-xs-12">


### PR DESCRIPTION
This fixes an issue where the course icon image was clipping through the border, and misaligned with the rest of the page.

**JIRA tickets**: OC-5205

**Dependencies**: None

**Screenshots**:
![screenshot_2018-09-09 redeem](https://user-images.githubusercontent.com/270966/45262679-5c6cbe00-b3d0-11e8-9b64-c7d0739472e9.png)

**Testing instructions**:

1. Add a coupon from https://localhost:8002/coupons
2. View the coupon offer by downloading the coupon CSV list, and opening one of the coupon URLs.
3. See that the course icon is within the border

**Reviewers**
- [ ] (@clemente)