### PR TITLE
[BB-2655] Initial implementation of the PayTabs payment processor

### DIFF
--- a/ecommerce/extensions/payment/processors/paytabs.py
+++ b/ecommerce/extensions/payment/processors/paytabs.py
@@ -1,0 +1,194 @@
+"""PayTabs payment processing."""
+
+import logging
+
+import six
+from django.conf import settings
+from django.urls import reverse
+from django.utils.functional import cached_property
+from ipware import get_client_ip
+import pycountry
+import requests
+from oscar.apps.payment.exceptions import GatewayError
+
+from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
+
+logger = logging.getLogger(__name__)
+
+
+class PayTabs(BasePaymentProcessor):
+    """
+    PayTabs payment processor.
+
+    For reference, see https://dev.paytabs.com/
+    """
+
+    NAME = 'paytabs'
+
+    def __init__(self, site):
+        super(PayTabs, self).__init__(site)
+        configuration = self.configuration
+        self.merchant_email = configuration['merchant_email']
+        self.secret_key = configuration['secret_key']
+        self.return_base_url = configuration['return_base_url']
+        self.site = site
+
+    def _get_user_profile_data(self, user, request):
+        """
+        Returns the profile data fields for the given user.
+        """
+        def get_extended_field(account_details, field_name, default_val=None):
+            """Helper function to extract data from the extended profile."""
+            return next(
+                (
+                    field.get('field_value', default_val) for field in account_details['extended_profile']
+                    if field['field_name'] == field_name
+                ),
+               default_val
+            )
+
+        account_details = user.account_details(request)
+        if account_details.get('country'):
+            # convert two letter country code to the three expected by paytabs
+            country_code = pycountry.countries.get(alpha_2=account_details.get('country')).alpha_3
+        else:
+            raise PayTabsException('Country must be set in user account settings')
+
+        return {
+            'first_name': get_extended_field(account_details, 'first_name'),
+            'last_name': get_extended_field(account_details, 'last_name'),
+            'mailing_address': get_extended_field(account_details, 'mailing_address'),
+            'city': get_extended_field(account_details, 'city'),
+            'country_code': country_code,
+            'phone_number': get_extended_field(account_details, 'phone_number'),
+            'postal_code': get_extended_field(account_details, 'ZIP/Postal Code', '11564'),
+            'state': get_extended_field(account_details, 'state'),
+        }
+
+    def _get_course_id_title(self, line):
+        """
+        Return the line title prefixed with the course ID, if available.
+        """
+        course_id = ''
+        line_course = line.product.course
+        if line_course:
+            course_id = '{}|'.format(line_course.id)
+        return course_id + line.product.title
+
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
+        """
+        Return the transaction parameters needed for this processor.
+        """
+        site_url = '{}://{}'.format(request.scheme, request.get_host())
+
+        # This can only be used in production when the requested site is publicly accessible on the internet
+        # via HTTPS
+        # return_url = request.build_absolute_uri(reverse('paytabs:submit'))
+        return_url = '{}{}'.format(self.return_base_url, reverse('paytabs:submit'))
+        client_ip, is_routable = get_client_ip(request)
+        ip_merchant = '-'
+        ip_customer = client_ip if is_routable else '-'
+        title = 'Order: {}'.format(basket.order_number)
+        user = basket.owner
+        user_profile_data = self._get_user_profile_data(user, request)
+        products = {'names': [], 'quantities': [], 'prices': []}
+        for line in basket.all_lines():
+            products['names'].append(self._get_course_id_title(line))
+            products['quantities'].append(six.text_type(line.quantity))
+            products['prices'].append(six.text_type(line.line_price_incl_tax_incl_discounts / line.quantity))
+
+        invoiced_products = {key: ' || '.join(val) for key, val in products.items()}
+        other_charges = '0.0'
+        amount = str(basket.total_incl_tax)
+        discount = '0.0'
+        currency = basket.currency
+        reference_no = basket.order_number
+        msg_lang = request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME) or settings.LANGUAGE_CODE
+        cms_with_version = 'Open edX E-Commerce'
+
+        pay_data = {
+            'merchant_email': self.merchant_email,
+            'secret_key': self.secret_key,
+            'site_url': site_url,
+            'return_url': return_url,
+            'title': title,
+            'cc_first_name': user_profile_data['first_name'],
+            'cc_last_name': user_profile_data['last_name'],
+            'cc_phone_number': self.configuration['default_phone_number_country_code'],
+            'phone_number': user_profile_data['phone_number'],
+            'email': user.email,
+            'products_per_title': invoiced_products['names'],
+            'unit_price': invoiced_products['prices'],
+            'quantity': invoiced_products['quantities'],
+            'other_charges': other_charges,
+            'amount': amount,
+            'discount': discount,
+            'currency': currency,
+            'reference_no': reference_no,
+            'ip_customer': ip_customer,
+            'ip_merchant': ip_merchant,
+            'billing_address': user_profile_data['mailing_address'],
+            'city': user_profile_data['city'],
+            'state': user_profile_data['state'],
+            'postal_code': user_profile_data['postal_code'],
+            'country': user_profile_data['country_code'],
+            'shipping_first_name': user_profile_data['first_name'],
+            'shipping_last_name': user_profile_data['last_name'],
+            'address_shipping': user_profile_data['mailing_address'],
+            'state_shipping': user_profile_data['state'],
+            'city_shipping': user_profile_data['city'],
+            'postal_code_shipping': user_profile_data['postal_code'],
+            'country_shipping': user_profile_data['country_code'],
+            'msg_lang': msg_lang,
+            'cms_with_version': cms_with_version,
+        }
+        # Creation of Payment Page
+        response = requests.post("https://www.paytabs.com/apiv2/create_pay_page", data=pay_data).json()
+        if response.get('response_code') != '4012':
+            err_msg = 'PayTabs raised an error when trying to process the payment (code: {response_code}, message: {result})'.format(**response)
+            raise PayTabsException(err_msg)
+
+        payment_url = response.get('payment_url')
+        return {
+            'payment_page_url': payment_url
+        }
+
+    def handle_processor_response(self, response, basket=None):
+        """
+        Handle the processor response.
+        """
+        if response['response_code'] != '100':
+            raise PayTabsException('PayTabs raised an error when trying to process the payment')
+
+        currency = response.get('currency')
+        total = response.get('amount')
+        transaction_id = response.get('transaction_id')
+        card_first_six_digits = response.get('card_first_six_digits', 'XXXXXX')
+        card_last_four_digits = response.get('card_last_four_digits', 'XXXX')
+        card_number = '{}XXXXXX{}'.format(card_first_six_digits, card_last_four_digits)
+        card_type = response.get('card_brand')
+        return HandledProcessorResponse(
+            transaction_id=transaction_id,
+            total=total,
+            currency=currency,
+            card_number=card_number,
+            card_type=card_type
+        )
+
+    def issue_credit(self, order_number, basket, reference_number, amount, currency):
+        """
+        This is currently not implemented.
+
+        While PayTabs supports this (https://dev.paytabs.com/docs/refund/), this endpoint is not available
+        for demo merchants.
+        """
+        logger.exception(
+            'PayTabs processor cannot issue credits or refunds at the moment.'
+        )
+
+
+class PayTabsException(GatewayError):
+    """
+    An umbrella exception to catch all errors from PayTabs.
+    """
+    pass  # pylint: disable=unnecessary-pass

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf.urls import include, url
 
-from ecommerce.extensions.payment.views import PaymentFailedView, SDNFailure, cybersource, paypal, stripe
+from ecommerce.extensions.payment.views import PaymentFailedView, SDNFailure, cybersource, paypal, stripe, paytabs
 
 CYBERSOURCE_APPLE_PAY_URLS = [
     url(r'^authorize/$', cybersource.CybersourceApplePayAuthorizationView.as_view(), name='authorize'),
@@ -28,10 +28,15 @@ STRIPE_URLS = [
     url(r'^submit/$', stripe.StripeSubmitView.as_view(), name='submit'),
 ]
 
+PAYTABS_URLS = [
+    url(r'submit/$', paytabs.PayTabsResponseView.as_view(), name='submit')
+]
+
 urlpatterns = [
     url(r'^cybersource/', include((CYBERSOURCE_URLS, 'cybersource'))),
     url(r'^error/$', PaymentFailedView.as_view(), name='payment_error'),
     url(r'^paypal/', include((PAYPAL_URLS, 'paypal'))),
     url(r'^sdn/', include((SDN_URLS, 'sdn'))),
     url(r'^stripe/', include((STRIPE_URLS, 'stripe'))),
+    url(r'^paytabs/', include((PAYTABS_URLS, 'paytabs'))),
 ]

--- a/ecommerce/extensions/payment/views/paytabs.py
+++ b/ecommerce/extensions/payment/views/paytabs.py
@@ -1,0 +1,133 @@
+"""PayTabs response processing views."""
+import logging
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
+from django.shortcuts import redirect
+from django.utils.decorators import method_decorator
+from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
+from oscar.apps.partner import strategy
+from oscar.core.loading import get_class, get_model
+import requests
+
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.extensions.checkout.utils import get_receipt_page_url
+from ecommerce.extensions.payment.processors.paytabs import PayTabs
+
+logger = logging.getLogger(__name__)
+
+Applicator = get_class('offer.applicator', 'Applicator')
+Basket = get_model('basket', 'Basket')
+OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
+OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
+NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
+
+PAYTABS_SUCCESS_CODES = ['100', '111']
+
+class PayTabsResponseView(EdxOrderPlacementMixin, View):
+    """
+    View to handle the response from PayTabs after processing the payment.
+    """
+    @property
+    def payment_processor(self):
+        return PayTabs(self.request.site)
+
+    @method_decorator(transaction.non_atomic_requests)
+    @method_decorator(csrf_exempt)
+    def dispatch(self, request, *args, **kwargs):
+        return super(PayTabsResponseView, self).dispatch(request, *args, **kwargs)
+
+    def _verify_response(self, request, payment_reference):
+        """
+        Verify the given payment_reference number to confirm that it is for a valid transaction
+        and return the verification response data.
+        """
+        partner_short_code = request.site.siteconfiguration.partner.short_code
+        configuration = settings.PAYMENT_PROCESSOR_CONFIG[partner_short_code.lower()][self.payment_processor.NAME]
+        api_parameters = {
+            "merchant_email": configuration['merchant_email'],
+            "secret_key": configuration['secret_key'],
+            "payment_reference": payment_reference
+        }
+        response = requests.post("https://www.paytabs.com/apiv2/verify_payment", data=api_parameters)
+        return response.json()
+
+    def _get_basket(self, basket_id):
+        """
+        Return the basket for the given id or None.
+        """
+        if not basket_id:
+            return None
+
+        try:
+            basket_id = int(basket_id)
+            basket = Basket.objects.get(id=basket_id)
+            basket.strategy = strategy.Default()
+            Applicator().apply(basket, basket.owner, self.request)
+            return basket
+        except (ValueError, ObjectDoesNotExist):
+            return None
+
+    def post(self, request):
+        """
+        Handle the POST request from PayTabs and redirect to the appropriate page based on the status.
+        """
+        transaction_id = 'Unknown'
+        basket = None
+        verification_data = {}
+        try:
+            payment_reference = request.POST.get('payment_reference')
+            if payment_reference is None:
+                logger.error('Received an invalid PayTabs merchant notification [%s]', request.POST)
+                return redirect(reverse('payment_error'))
+
+            logger.info('Received PayTabs merchant notification with payment_reference %s', payment_reference)
+            verification_data = self._verify_response(request, payment_reference)
+            if not verification_data['response_code'] in PAYTABS_SUCCESS_CODES:
+                logger.error(
+                    'Received an error (%i) from PayTabs merchant notification [%s]',
+                    verification_data['response_code'],
+                    request.POST
+                )
+                return redirect(reverse('payment_error'))
+            reference_number = verification_data['reference_no']
+            basket_id = OrderNumberGenerator().basket_id(reference_number)
+            basket = self._get_basket(basket_id)
+            transaction_id = verification_data['transaction_id']
+            if not basket:
+                logger.error('Received payment for non-existent basket [%s].', basket_id)
+                return redirect(reverse('payment_error'))
+        finally:
+            payment_processor_response = self.payment_processor.record_processor_response(
+                request.POST, transaction_id=transaction_id, basket=basket
+            )
+
+        try:
+            with transaction.atomic():
+                try:
+                    self.handle_payment(verification_data, basket)
+                except Exception as exc:
+                    logger.exception(
+                        'PayTabs payment did not complete for basket [%d] because of [%s]. '
+                        'The payment response was recorded in entry [%d].',
+                        basket.id,
+                        exc.__class__.__name__,
+                        payment_processor_response.id
+                    )
+                    raise
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception(
+                'Attempts to handle payment for basket [%d] failed due to [%s].',
+                basket.id,
+                exc.__class__.__name__
+            )
+            return redirect(reverse('payment_error'))
+        self.create_order(request, basket)
+        receipt_url = get_receipt_page_url(
+            order_number=basket.order_number,
+            site_configuration=basket.site.siteconfiguration
+        )
+        return redirect(receipt_url)

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -129,6 +129,7 @@ PAYMENT_PROCESSORS = (
     'ecommerce.extensions.payment.processors.cybersource.Cybersource',
     'ecommerce.extensions.payment.processors.paypal.Paypal',
     'ecommerce.extensions.payment.processors.stripe.Stripe',
+    'ecommerce.extensions.payment.processors.paytabs.PayTabs',
 )
 
 PAYMENT_PROCESSOR_RECEIPT_PATH = '/checkout/receipt/'

--- a/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -165,6 +165,8 @@
                             {% elif processor.NAME == 'paypal' %}
                                 {# Translators: Do NOT translate the name PayPal. #}
                                 {% trans "Checkout with PayPal" as tmsg %}{{ tmsg | force_escape }}
+                            {% elif processor.NAME == 'paytabs' %}
+                                {% trans "Checkout with PayTabs" %}
                             {% endif %}
                         </button>
                     {% endfor %}

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,6 +9,7 @@ django-cors-headers                 #  Used to allow to configure CORS headers f
 django-crispy-forms<1.9.0
 django_extensions
 django-filter
+django-ipware==2.1.0
 django-libsass
 django-oscar
 django-rest-swagger

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,6 +32,7 @@ django-extensions==2.2.9  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.2.0      # via -r requirements/base.in
 django-haystack==2.8.1    # via django-oscar
+django-ipware==2.1.0      # via -r requirements/base.in
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==3.2.0  # via edx-rbac
 django-oscar==2.0.4       # via -r requirements/base.in


### PR DESCRIPTION
This PR adds a new payment processor to ecommerce which uses the PayTabs payment gateway.

**JIRA tickets**: Implements BB-2655

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Configure ecommerce on devstack to use paytabs as the default payment processor from [the SiteConfiguration options](http://localhost:18130/admin/core/siteconfiguration/1/change/)
2. Add a [waffle switch in ecommerce](http://localhost:18130/admin/waffle/switch/) with the name `payment_processor_active_paytabs` to enable the processor
3. Disable, or add and disable, the [waffle flag](http://localhost:18130/admin/waffle/flag/) named `enable_client_side_checkout` to force checkouts to direct to the PayTabs site
4. Update the SiteConfiguration with the necessary extended profile fields: `"extended_profile_fields":["first_name","last_name","phone_number","mailing_address","city","state"]`
5. Go to the [account settings page](http://localhost:18000/account/settings) to fill in the necessary fields configured above.
6. Login as a test student user and [upgrade your demonstration course enrollment to verified](http://localhost:18130/basket/add/?sku=8CF08E5) using ecommerce. This will add the upgrade to the basket, and prompt to "Checkout with PayTabs".

**Author notes and concerns**:

1. This relies on pycountries which is slated for removal, but this will need to be re-implemented in later versions of edX in any case.

**Reviewers**
- [ ] (@farhaanbukhsh)