### PR TITLE
[BB-3801] feat: install extra requirements in the tox environments

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,0 +1,2 @@
+# If there are any Python packages you want to keep in your virtualenv beyond
+# those listed in the official requirements files, list them here.

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ setenv =
     SELENIUM_BROWSER=firefox
 deps =
     -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/extra.txt
     django22: Django>=2.2,<2.3
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
This is necessary when the extra requirements (defined in the `ECOMMERCE_EXTRA_REQUIREMENTS` ansible variable) are added to `INSTALLED_APPS` and hence have to be installed in the virtualenv environments used for the various Django management commands like `migrate` for example.