### PR TITLE
BB-4552: Add support for fixed rate for all products

### DIFF
--- a/ecommerce/extensions/partner/strategy.py
+++ b/ecommerce/extensions/partner/strategy.py
@@ -1,5 +1,7 @@
 
 
+from decimal import Decimal
+from django.conf import settings
 from django.utils import timezone
 from oscar.apps.partner import availability, strategy
 from oscar.core.loading import get_model
@@ -33,8 +35,18 @@ class CourseSeatAvailabilityPolicyMixin(strategy.StockRequired):
         return availability.Unavailable()
 
 
+class TaxStrategyMixin(strategy.FixedRateTax):
+    """
+    Tax strategy for e-commerce pricing.
+    Defaults to 0% tax, but allows setting a fixed tax rate through Django settings.
+    """
+
+    @property
+    def rate(self):
+        return Decimal(settings.TAX_RATE)
+
 class DefaultStrategy(strategy.UseFirstStockRecord, CourseSeatAvailabilityPolicyMixin,
-                      strategy.NoTax, strategy.Structured):
+                      TaxStrategyMixin, strategy.Structured):
     """ Default Strategy """
 
 

--- a/ecommerce/extensions/partner/tests/test_strategy.py
+++ b/ecommerce/extensions/partner/tests/test_strategy.py
@@ -4,6 +4,9 @@ import datetime
 
 import ddt
 import pytz
+from decimal import Decimal
+
+from django.test import override_settings
 from django.test import RequestFactory
 from oscar.apps.partner import availability
 
@@ -66,6 +69,11 @@ class DefaultStrategyTests(DiscoveryTestMixin, TestCase):
         stock_record = product.stockrecords.first()
         actual = strategy.availability_policy(product, stock_record)
         self.assertIsInstance(actual, available)
+
+    @override_settings(TAX_RATE="0.3")
+    def test_get_rate(self):
+        strategy = DefaultStrategy()
+        self.assertEqual(strategy.get_rate(None, None), Decimal("0.3"))
 
 
 class SelectorTests(TestCase):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -14,7 +14,6 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from edx_django_utils import monitoring as monitoring_utils
-from oscar.apps.partner import strategy
 from oscar.apps.payment.exceptions import GatewayError, PaymentError, TransactionDeclined, UserCancelled
 from oscar.core.loading import get_class, get_model
 from rest_framework import permissions, status
@@ -59,6 +58,7 @@ Order = get_model('order', 'Order')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+Selector = get_class('partner.strategy', 'Selector')
 
 
 class CyberSourceProcessorMixin:
@@ -394,7 +394,7 @@ class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
         try:
             basket_id = int(basket_id)
             basket = Basket.objects.get(id=basket_id)
-            basket.strategy = strategy.Default()
+            basket.strategy = Selector().strategy()
 
             Applicator().apply(basket, basket.owner, self.request)
             logger.info(

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -12,7 +12,6 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from oscar.apps.partner import strategy
 from oscar.apps.payment.exceptions import PaymentError
 from oscar.core.loading import get_class, get_model
 
@@ -31,6 +30,7 @@ NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+Selector = get_class('partner.strategy', 'Selector')
 
 
 class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
@@ -65,7 +65,7 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
                 processor_name=self.payment_processor.NAME,
                 transaction_id=payment_id
             ).basket
-            basket.strategy = strategy.Default()
+            basket.strategy = Selector().strategy()
 
             Applicator().apply(basket, basket.owner, self.request)
 

--- a/ecommerce/management/utils.py
+++ b/ecommerce/management/utils.py
@@ -3,7 +3,6 @@
 import logging
 
 from django.db.models import Q
-from oscar.apps.partner import strategy
 from oscar.core.loading import get_class, get_model
 
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
@@ -20,6 +19,7 @@ NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
 Order = get_model('order', 'Order')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
 ShippingEventType = get_model('order', 'ShippingEventType')
+Selector = get_class('partner.strategy', 'Selector')
 
 SHIPPING_EVENT_NAME = 'Shipped'
 
@@ -44,7 +44,7 @@ def refund_basket_transactions(site, basket_ids):
     failure_count = 0
 
     for basket in baskets:
-        basket.strategy = strategy.Default()
+        basket.strategy = Selector().strategy()
         Applicator().apply(basket, basket.owner, None)
 
         logger.info('Refunding transactions for basket [%d]...', basket.id)
@@ -140,7 +140,7 @@ class FulfillFrozenBaskets(EdxOrderPlacementMixin):
 
         # if no order exists we need to create a new order.
         if not order:
-            basket.strategy = strategy.Default()
+            basket.strategy = Selector().strategy()
 
             # Need to handle the case that applied voucher has been expired.
             # This will create the order  with out discount but subsequently

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -834,3 +834,6 @@ HUBSPOT_SALES_LEAD_FORM_GUID = "SET-ME-PLEASE"
 # To check government purchase restriction lists
 SDN_CHECK_API_URL ="https://api.trade.gov/gateway/v1/consolidated_screening_list/search"
 SDN_CHECK_API_KEY = "sdn search key here"
+
+# Set a fixed tax rate for all products
+TAX_RATE = '0.0'


### PR DESCRIPTION
This PR adds support for a fixed tax rate setting in ecommerce through a new django settings (
TAX_RATE), which default value is 0.0, preserving the previous platform behaviour.

Testing instructions:
- Check that the added tests make sense
- Change the setting to a decimal value(like "0.3") and verify that the total value displayed on basket and invoice includes the tax rate, could be tested with the verified certificate purchase