### PR TITLE
BB-4730: Return `price_incl_tax` as price on ProductSerializer 

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -197,7 +197,7 @@ class ProductPaymentInfoMixin(serializers.ModelSerializer):
     def get_price(self, product):
         info = self._get_info(product)
         if info.availability.is_available_to_buy:
-            return serializers.DecimalField(max_digits=10, decimal_places=2).to_representation(info.price.excl_tax)
+            return serializers.DecimalField(max_digits=10, decimal_places=2).to_representation(info.price.incl_tax)
         return None
 
     def _get_info(self, product):


### PR DESCRIPTION
This allows external services (such as course discovery) to retrieve prices with tax when `TAX_RATE` is enabled.
This change retains the previous default behavior: `price_incl_tax` when `TAX_RATE = 0` will be the same as `price_excl_tax`.

**Testing instructions:**
Check the related PR for testing instructions: https://github.com/open-craft/course-discovery/pull/3 

**Reviewers:**
- [x] @tinumide 